### PR TITLE
Fix lack of add-opens when running jmx itest

### DIFF
--- a/as/itests/org.jboss.tools.as.jmx.ui.bot.itests/pom.xml
+++ b/as/itests/org.jboss.tools.as.jmx.ui.bot.itests/pom.xml
@@ -17,7 +17,7 @@
 		<maven.test.failure.ignore>true</maven.test.failure.ignore>
 		<rd.config>${project.build.directory}/classes/requirements.json</rd.config>
 		<skipPrivateRequirements>false</skipPrivateRequirements>
-		<systemProperties>-Drd.config=${rd.config} -Dusage_reporting_enabled=false -Djbosstools.test.wildfly.26.home=${jbosstools.test.wildfly.26.home} -Djbosstools.test.wildfly.27.home=${jbosstools.test.wildfly.27.home} -Djbosstools.test.eap.7.4.home=${jbosstools.test.eap.7.4.home} -Dusername=${username} -Dpassword=${password} -Dremote.system.type=${remote.system.type}</systemProperties>
+		<systemProperties>-Drd.config=${rd.config} -Dusage_reporting_enabled=false -Djbosstools.test.wildfly.26.home=${jbosstools.test.wildfly.26.home} -Djbosstools.test.wildfly.27.home=${jbosstools.test.wildfly.27.home} -Djbosstools.test.eap.7.4.home=${jbosstools.test.eap.7.4.home} -Dusername=${username} -Dpassword=${password} -Dremote.system.type='${remote.system.type}' ${additionalProperties}</systemProperties>
 		<surefire.timeout>14400</surefire.timeout>
 		<username></username>
 		<password></password>


### PR DESCRIPTION
# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
